### PR TITLE
Set the _Ptr pointer to nullptr when destroy the coroutine.

### DIFF
--- a/stl/inc/coroutine
+++ b/stl/inc/coroutine
@@ -142,6 +142,7 @@ struct coroutine_handle {
 
     void destroy() const noexcept { // strengthened
         __builtin_coro_destroy(_Ptr);
+        _Ptr = nullptr;
     }
 
     _NODISCARD _CoroPromise& promise() const noexcept { // strengthened


### PR DESCRIPTION
After coroutine::destroy is invoked, an exception occurs if other methods related to this thread, such as resume() and done(), are invoked again. This usually occurs when multiple threads work on the same coroutine object. The C++ standard doesn't explicitly define how coroutine::destroy is implemented, but I think doing so would make the application more robust.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
